### PR TITLE
Unblock the FLoRA pipeline, and carry alt_identifier_r through the COS branch

### DIFF
--- a/pipelines/flora/prepare_flora.qmd
+++ b/pipelines/flora/prepare_flora.qmd
@@ -97,12 +97,17 @@ reproductions <- reproductions %>%
 cat(sprintf("    ✓ Filtered to %d validated reproductions\n", nrow(reproductions)))
 
 # Combine both datasets (handle case where one might be empty)
-# Add source variable to track data origin. Both source sheets use
-# `out_quote_source`; the rest of the pipeline (and downstream COS/SCORE
-# branches) use `outcome_quote_source`, so harmonise here.
+# Add source variable to track data origin. The replications sheet uses
+# `out_quote_source` and the rest of the pipeline (and the COS/SCORE branches)
+# use `outcome_quote_source`, so harmonise here. The reproductions sheet has
+# NEITHER — it carries the two-axis vocabulary (`out_quote_computational_source`,
+# `out_quote_robust_source`) — so the rename must be a no-op when the column is
+# absent. `rename_with(~ "outcome_quote_source", ...)` was not: a constant .fn
+# returns length 1 against an empty selection, which dplyr rejects, and that is
+# what has failed every run since the reproductions sheet changed.
 tag_source <- function(df, type_label, source_label) {
   df %>%
-    rename_with(~ "outcome_quote_source", any_of("out_quote_source")) %>%
+    rename(any_of(c(outcome_quote_source = "out_quote_source"))) %>%
     mutate(type = type_label, source = source_label)
 }
 if (nrow(reproductions) == 0) {
@@ -139,6 +144,15 @@ cat(sprintf("    ✓ Rewrote %d shorthand outcome quotes\n",
                            "^Coded as |^Replicated = |^Rep\\. (s1|s2|s1\\+s2) = |^95% CI for the meta-analytic |^Subjective replication success rating |^Classified as mixed:|^Outcome classified as "),
                 na.rm = TRUE)))
 
+# `alt_identifier_r` is an optional source-sheet column (see Data Preparation):
+# on the COS sheet it holds the OSF registration DOIs for the replication report,
+# which is the only identifier those records have. The summarise below keeps an
+# explicit column list, so a column absent from it is silently dropped before
+# `flora_cols` can select it — ensure it exists, then carry it.
+if (!"alt_identifier_r" %in% names(replications_cos)) {
+  replications_cos$alt_identifier_r <- NA_character_
+}
+
 replications_cos <- replications_cos %>%
   mutate(repl_id = coalesce(url_r, doi_r)) %>%
   group_by(doi_o, repl_id) %>%
@@ -147,6 +161,7 @@ replications_cos <- replications_cos %>%
     ref_r = first(ref_r),
     url_r = first(url_r),
     doi_r = first(doi_r),
+    alt_identifier_r = first(alt_identifier_r),
     abstract_r = first(abstract_r),
     outcome = if (length(unique(outcome)) == 1) unique(outcome) else "mixed",
     outcome_quote = paste(unique(na.omit(outcome_quote)), collapse = " || "),


### PR DESCRIPTION
Two defects in `pipelines/flora/prepare_flora.qmd`: one has been failing every scheduled run since at least 2026-08-01, the other would silently drop a column that is now carrying real data.

## 1. The pipeline is dead in `download-data`

```
Error in `rename_with()`:
! `.fn` must return a vector of length 0, not 1.
 3. ├─global tag_source(reproductions, "reproduction", "reproductions")
 6. ├─dplyr::rename_with(., ~"outcome_quote_source", any_of("out_quote_source"))
```

`tag_source()` passes a **constant** `.fn`, which returns length 1 no matter what the selection is. That is fine for the replications sheet, which has `out_quote_source` — but the reproductions sheet has no such column at all. It carries the two-axis vocabulary instead: `out_quote_computational_source` and `out_quote_robust_source`. So `any_of()` selects nothing, the constant returns 1 against a selection of 0, and dplyr aborts.

The code's own comment ("Both source sheets use `out_quote_source`") records the assumption that stopped being true. `rename(any_of(c(new = old)))` is a genuine no-op when the column is absent.

Runs 30683365313 (08-01), 30731938437, 30783822730, 30876502246, 30973973212 (08-05) all died here, so `output/flora.csv` has been stale for at least five days.

## 2. `alt_identifier_r` never reaches `doi_r_alt` on the COS branch

The COS `summarise()` keeps an explicit column list, so anything not named in it is dropped before `flora_cols` can select it. `alt_identifier_r` was not named, which did not matter while the COS sheet had no such column — it now does.

**Why it now has data.** The RPP rows are the reason. FLoRA holds 92 of them, one per replicated original with its own outcome, but all keyed to the aggregate Science paper in `doi_r`, with the individual replication reachable only through `url_r`. Those `url_r` pages are OSF project nodes, and **0 of 91 have a DOI of their own** — `/v2/nodes/<guid>/identifiers/` is empty for every one, and a constructed `10.17605/OSF.IO/<node-guid>` 404s at DataCite.

What each report does have is a **post-completion registration snapshot** that carries a real DOI: 118 of 129 were registered in July 2015, weeks before RPP was published, with the single response *"Registered prior to RPP publication"*, and the registration's file listing is `Archive of OSF Storage` — a frozen copy of the node holding e.g. `Final Report Harmon-Jones et al 2008 Study 2 Replication - Mechin&Gable.docx`. So it is the report, archived and citable.

Those DOIs are now in `alt_identifier_r` on the COS sheet (all 117 distinct values verified to resolve at DataCite), with `url_r` pointed at the DOI so the citation target cannot change under it. 83 report nodes are covered; 8 have no registration at all and were left untouched rather than given an invented identifier.

## Effect

Simulating the COS branch against the live sheet with this patch: **92 RPP rows reach `flora.csv` (unchanged — the dedup grouping is unaffected), 84 of them with `doi_r_alt` populated**, 8 without.

```
                     doi_o                   doi_r                                 url_r                             doi_r_alt
  10.1037/0022-3514.94.1.1 10.1126/science.aac4716 https://doi.org/10.17605/OSF.IO/RQTGZ                 10.17605/OSF.IO/RQTGZ
10.1037/0022-3514.94.1.116 10.1126/science.aac4716 https://doi.org/10.17605/OSF.IO/RNE5U 10.17605/OSF.IO/RNE5U, 10.17605/OSF.IO/3M7QW
```

Multi-valued rows are nodes RPP registered twice (2015-07-13 and 2015-07-23/24); both snapshots are equally the report, and `append_alt_identifier()` already treats this column as a comma-separated list, so nothing has to pick between them.

The guard `if (!"alt_identifier_r" %in% names(replications_cos))` keeps the branch working if the column is ever removed from the sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
